### PR TITLE
improve: [0011] パンパネの最小横長指定を設定

### DIFF
--- a/js/pstyle.js
+++ b/js/pstyle.js
@@ -45,6 +45,7 @@ g_keyObj.keyCtrl18p_0 = [[55, 0], [56, 0], [57, 0], [48, 0], [189, 0], [85, 0], 
 g_keyObj.keyCtrl18p_1 = [[50, 0], [51, 0], [52, 0], [53, 0], [54, 0], [87, 0], [69, 0], [82, 0], [84, 0], [83, 0], [68, 0], [70, 0], [71, 0], [90, 0], [88, 0], [67, 0], [86, 0], [66, 0]];
 g_keyObj.div18p_0 = 18;
 g_keyObj.div18p_1 = 18;
+g_keyObj.minWidth18p = 650;
 
 g_rootObj.imgType = `panels,svg,true,0`;
 g_rootObj.arrowJdgY = -160;

--- a/punpane/Komichi.html
+++ b/punpane/Komichi.html
@@ -91,7 +91,7 @@ a:hover  { color:#FF9900; text-decoration: underline; }
 
 |tuning=ティックル|hashTag=#punpane|
 '>
-<div id="canvas-frame" style="width:650px;margin:auto;">
+<div id="canvas-frame">
 	<p>ゲームを準備しています...</p>
 	<p>このメッセージがいつまでも消えない場合、<br>
 		Google ChromeやFirefox等、HTML5に対応したブラウザをご利用ください。</p>


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
1. 最小横長指定を設定しました。
これにより、canvas-frameのstyle属性の指定が必要となります。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. 本体のバージョンアップで「minWidth」が実装されたため、
キー数設定側での制御が可能になりました。650pxを最小値として設定しています。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments