### PR TITLE
feat: [0013] 36Panel対応、コード整理

### DIFF
--- a/css/pstyle_36p.css
+++ b/css/pstyle_36p.css
@@ -1,0 +1,1755 @@
+﻿@charset "UTF-8";
+/* ----------------------------------------
+  Punching◇Panels (36 Panel)
+  カスタムcssファイル
+
+  Created : 2024/12/14
+  Revised : 
+
+  https://github.com/cwtickle/punching-panels
+------------------------------------------ */
+
+div[id^="stepHit"] {
+    top: -10px !important;
+}
+
+.j11,
+.j12,
+.j13,
+.j14,
+.j15,
+.j21,
+.j22,
+.j23,
+.j24,
+.j31,
+.j32,
+.j33,
+.j34,
+.j41,
+.j42,
+.j43,
+.j44,
+.j45,
+.j16,
+.j17,
+.j18,
+.j19,
+.j1a,
+.j26,
+.j27,
+.j28,
+.j29,
+.j36,
+.j37,
+.j38,
+.j39,
+.j46,
+.j47,
+.j48,
+.j49,
+.j4a {
+    animation-timing-function: linear, step-end;
+    animation-fill-mode: forwards;
+}
+
+.j11,
+.j21,
+.j31,
+.j41,
+.j16,
+.j26,
+.j36,
+.j46 {
+    border: 2px solid #6666ff;
+    background: #000066;
+}
+
+.j12,
+.j22,
+.j32,
+.j42,
+.j17,
+.j27,
+.j37,
+.j47 {
+    border: 2px solid #66ffff;
+    background: #003333;
+}
+
+.j13,
+.j43,
+.j18,
+.j48 {
+    border: 2px solid #ffffff;
+    background: #333333;
+}
+
+.j14,
+.j23,
+.j33,
+.j44,
+.j19,
+.j28,
+.j38,
+.j49 {
+    border: 2px solid #ffff66;
+    background: #333300;
+}
+
+.j15,
+.j24,
+.j34,
+.j45,
+.j1a,
+.j29,
+.j39,
+.j4a {
+    border: 2px solid #ff9966;
+    background: #663300;
+}
+
+.j11 {
+    animation-name: move11;
+    top: 50px;
+}
+
+.j12 {
+    animation-name: move12;
+    top: 50px;
+}
+
+.j13 {
+    animation-name: move13;
+    top: 50px;
+}
+
+.j14 {
+    animation-name: move14;
+    top: 50px;
+}
+
+.j15 {
+    animation-name: move15;
+    top: 50px;
+}
+
+.j16 {
+    animation-name: move16;
+    top: 50px;
+}
+
+.j17 {
+    animation-name: move17;
+    top: 50px;
+}
+
+.j18 {
+    animation-name: move18;
+    top: 50px;
+}
+
+.j19 {
+    animation-name: move19;
+    top: 50px;
+}
+
+.j1a {
+    animation-name: move1a;
+    top: 50px;
+}
+
+@keyframes move11 {
+    0% {
+        left: 0px;
+        top: 110px;
+        width: 50px;
+        height: 0px;
+        background: #ffffff;
+    }
+
+    100% {
+        left: 100px;
+        top: 110px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move12 {
+    0% {
+        left: 120px;
+        top: 80px;
+        width: 50px;
+        height: 0px;
+        background: #ffffff;
+    }
+
+    100% {
+        left: 200px;
+        top: 110px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move13 {
+    0% {
+        left: 300px;
+        top: 60px;
+        width: 50px;
+        height: 0px;
+        background: #ffffff;
+    }
+
+    100% {
+        left: 300px;
+        top: 110px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move14 {
+    0% {
+        left: 480px;
+        top: 80px;
+        width: 50px;
+        height: 0px;
+        background: #ffffff;
+    }
+
+    100% {
+        left: 400px;
+        top: 110px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move15 {
+    0% {
+        left: 600px;
+        top: 110px;
+        width: 50px;
+        height: 0px;
+        background: #ffffff;
+    }
+
+    100% {
+        left: 500px;
+        top: 110px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move16 {
+    0% {
+        left: 500px;
+        top: 110px;
+        width: 50px;
+        height: 0px;
+        background: #ffffff;
+    }
+
+    100% {
+        left: 600px;
+        top: 110px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move17 {
+    0% {
+        left: 620px;
+        top: 80px;
+        width: 50px;
+        height: 0px;
+        background: #ffffff;
+    }
+
+    100% {
+        left: 700px;
+        top: 110px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move18 {
+    0% {
+        left: 800px;
+        top: 60px;
+        width: 50px;
+        height: 0px;
+        background: #ffffff;
+    }
+
+    100% {
+        left: 800px;
+        top: 110px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move19 {
+    0% {
+        left: 980px;
+        top: 80px;
+        width: 50px;
+        height: 0px;
+        background: #ffffff;
+    }
+
+    100% {
+        left: 900px;
+        top: 110px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move1a {
+    0% {
+        left: 1100px;
+        top: 110px;
+        width: 50px;
+        height: 0px;
+        background: #ffffff;
+    }
+
+    100% {
+        left: 1000px;
+        top: 110px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+.j21 {
+    animation-name: move21;
+    top: 150px;
+}
+
+.j22 {
+    animation-name: move22;
+    top: 150px;
+}
+
+.j23 {
+    animation-name: move23;
+    top: 150px;
+}
+
+.j24 {
+    animation-name: move24;
+    top: 150px;
+}
+
+.j26 {
+    animation-name: move26;
+    top: 150px;
+}
+
+.j27 {
+    animation-name: move27;
+    top: 150px;
+}
+
+.j28 {
+    animation-name: move28;
+    top: 150px;
+}
+
+.j29 {
+    animation-name: move29;
+    top: 150px;
+}
+
+@keyframes move21 {
+    0% {
+        left: 50px;
+        top: 170px;
+        width: 50px;
+        height: 0px;
+        background: #ffffff;
+    }
+
+    100% {
+        left: 150px;
+        top: 170px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move22 {
+    0% {
+        left: 170px;
+        top: 140px;
+        width: 50px;
+        height: 0px;
+        background: #ffffff;
+    }
+
+    100% {
+        left: 250px;
+        top: 170px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move23 {
+    0% {
+        left: 430px;
+        top: 140px;
+        width: 50px;
+        height: 0px;
+        background: #ffffff;
+    }
+
+    100% {
+        left: 350px;
+        top: 170px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move24 {
+    0% {
+        left: 550px;
+        top: 170px;
+        width: 50px;
+        height: 0px;
+        background: #ffffff;
+    }
+
+    100% {
+        left: 450px;
+        top: 170px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move26 {
+    0% {
+        left: 550px;
+        top: 170px;
+        width: 50px;
+        height: 0px;
+        background: #ffffff;
+    }
+
+    100% {
+        left: 650px;
+        top: 170px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move27 {
+    0% {
+        left: 670px;
+        top: 140px;
+        width: 50px;
+        height: 0px;
+        background: #ffffff;
+    }
+
+    100% {
+        left: 750px;
+        top: 170px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move28 {
+    0% {
+        left: 930px;
+        top: 140px;
+        width: 50px;
+        height: 0px;
+        background: #ffffff;
+    }
+
+    100% {
+        left: 850px;
+        top: 170px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move29 {
+    0% {
+        left: 1050px;
+        top: 170px;
+        width: 50px;
+        height: 0px;
+        background: #ffffff;
+    }
+
+    100% {
+        left: 950px;
+        top: 170px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+.j31 {
+    animation-name: move31;
+    top: 250px;
+}
+
+.j32 {
+    animation-name: move32;
+    top: 250px;
+}
+
+.j33 {
+    animation-name: move33;
+    top: 250px;
+}
+
+.j34 {
+    animation-name: move34;
+    top: 250px;
+}
+
+.j36 {
+    animation-name: move36;
+    top: 250px;
+}
+
+.j37 {
+    animation-name: move37;
+    top: 250px;
+}
+
+.j38 {
+    animation-name: move38;
+    top: 250px;
+}
+
+.j39 {
+    animation-name: move39;
+    top: 250px;
+}
+
+@keyframes move31 {
+    0% {
+        left: 50px;
+        top: 230px;
+        width: 50px;
+        height: 0px;
+        background: #ffffff;
+    }
+
+    100% {
+        left: 150px;
+        top: 230px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move32 {
+    0% {
+        left: 170px;
+        top: 260px;
+        width: 50px;
+        height: 0px;
+        background: #ffffff;
+    }
+
+    100% {
+        left: 250px;
+        top: 230px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move33 {
+    0% {
+        left: 430px;
+        top: 260px;
+        width: 50px;
+        height: 0px;
+        background: #ffffff;
+    }
+
+    100% {
+        left: 350px;
+        top: 230px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move34 {
+    0% {
+        left: 550px;
+        top: 230px;
+        width: 50px;
+        height: 0px;
+        background: #ffffff;
+    }
+
+    100% {
+        left: 450px;
+        top: 230px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move36 {
+    0% {
+        left: 550px;
+        top: 230px;
+        width: 50px;
+        height: 0px;
+        background: #ffffff;
+    }
+
+    100% {
+        left: 650px;
+        top: 230px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move37 {
+    0% {
+        left: 670px;
+        top: 260px;
+        width: 50px;
+        height: 0px;
+        background: #ffffff;
+    }
+
+    100% {
+        left: 750px;
+        top: 230px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move38 {
+    0% {
+        left: 930px;
+        top: 260px;
+        width: 50px;
+        height: 0px;
+        background: #ffffff;
+    }
+
+    100% {
+        left: 850px;
+        top: 230px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move39 {
+    0% {
+        left: 1050px;
+        top: 230px;
+        width: 50px;
+        height: 0px;
+        background: #ffffff;
+    }
+
+    100% {
+        left: 950px;
+        top: 230px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+.j41 {
+    animation-name: move41;
+    top: 350px;
+}
+
+.j42 {
+    animation-name: move42;
+    top: 350px;
+}
+
+.j43 {
+    animation-name: move43;
+    top: 350px;
+}
+
+.j44 {
+    animation-name: move44;
+    top: 350px;
+}
+
+.j45 {
+    animation-name: move45;
+    top: 350px;
+}
+
+.j46 {
+    animation-name: move46;
+    top: 350px;
+}
+
+.j47 {
+    animation-name: move47;
+    top: 350px;
+}
+
+.j48 {
+    animation-name: move48;
+    top: 350px;
+}
+
+.j49 {
+    animation-name: move49;
+    top: 350px;
+}
+
+.j4a {
+    animation-name: move4a;
+    top: 350px;
+}
+
+@keyframes move41 {
+    0% {
+        left: 0px;
+        top: 290px;
+        width: 50px;
+        height: 0px;
+        background: #ffffff;
+    }
+
+    100% {
+        left: 100px;
+        top: 290px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move42 {
+    0% {
+        left: 120px;
+        top: 340px;
+        width: 50px;
+        height: 0px;
+        background: #ffffff;
+    }
+
+    100% {
+        left: 200px;
+        top: 290px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move43 {
+    0% {
+        left: 300px;
+        top: 390px;
+        width: 50px;
+        height: 0px;
+        background: #ffffff;
+    }
+
+    100% {
+        left: 300px;
+        top: 290px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move44 {
+    0% {
+        left: 480px;
+        top: 340px;
+        width: 50px;
+        height: 0px;
+        background: #ffffff;
+    }
+
+    100% {
+        left: 400px;
+        top: 290px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move45 {
+    0% {
+        left: 600px;
+        top: 290px;
+        width: 50px;
+        height: 0px;
+        background: #ffffff;
+    }
+
+    100% {
+        left: 500px;
+        top: 290px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move46 {
+    0% {
+        left: 500px;
+        top: 290px;
+        width: 50px;
+        height: 0px;
+        background: #ffffff;
+    }
+
+    100% {
+        left: 600px;
+        top: 290px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move47 {
+    0% {
+        left: 620px;
+        top: 340px;
+        width: 50px;
+        height: 0px;
+        background: #ffffff;
+    }
+
+    100% {
+        left: 700px;
+        top: 290px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move48 {
+    0% {
+        left: 800px;
+        top: 390px;
+        width: 50px;
+        height: 0px;
+        background: #ffffff;
+    }
+
+    100% {
+        left: 800px;
+        top: 290px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move49 {
+    0% {
+        left: 980px;
+        top: 340px;
+        width: 50px;
+        height: 0px;
+        background: #ffffff;
+    }
+
+    100% {
+        left: 900px;
+        top: 290px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move4a {
+    0% {
+        left: 1100px;
+        top: 290px;
+        width: 50px;
+        height: 0px;
+        background: #ffffff;
+    }
+
+    100% {
+        left: 1000px;
+        top: 290px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+
+.j11_org,
+.j12_org,
+.j13_org,
+.j14_org,
+.j15_org,
+.j21_org,
+.j22_org,
+.j23_org,
+.j24_org,
+.j31_org,
+.j32_org,
+.j33_org,
+.j34_org,
+.j41_org,
+.j42_org,
+.j43_org,
+.j44_org,
+.j45_org,
+.j16_org,
+.j17_org,
+.j18_org,
+.j19_org,
+.j1a_org,
+.j26_org,
+.j27_org,
+.j28_org,
+.j29_org,
+.j36_org,
+.j37_org,
+.j38_org,
+.j39_org,
+.j46_org,
+.j47_org,
+.j48_org,
+.j49_org,
+.j4a_org {
+    animation-timing-function: linear, step-end;
+    animation-fill-mode: forwards;
+}
+
+.j11_org,
+.j21_org,
+.j31_org,
+.j41_org,
+.j16_org,
+.j26_org,
+.j36_org,
+.j46_org {
+    border: 2px solid #6666ff;
+    background: #000066;
+}
+
+.j12_org,
+.j22_org,
+.j32_org,
+.j42_org,
+.j17_org,
+.j27_org,
+.j37_org,
+.j47_org {
+    border: 2px solid #66ffff;
+    background: #003333;
+}
+
+.j13_org,
+.j43_org,
+.j18_org,
+.j48_org {
+    border: 2px solid #ffffff;
+    background: #333333;
+}
+
+.j14_org,
+.j23_org,
+.j33_org,
+.j44_org,
+.j19_org,
+.j28_org,
+.j38_org,
+.j49_org {
+    border: 2px solid #ffff66;
+    background: #333300;
+}
+
+.j15_org,
+.j24_org,
+.j34_org,
+.j45_org,
+.j1a_org,
+.j29_org,
+.j39_org,
+.j4a_org {
+    border: 2px solid #ff9966;
+    background: #663300;
+}
+
+.j11_org {
+    animation-name: move11_org;
+    top: 50px;
+}
+
+.j12_org {
+    animation-name: move12_org;
+    top: 50px;
+}
+
+.j13_org {
+    animation-name: move13_org;
+    top: 50px;
+}
+
+.j14_org {
+    animation-name: move14_org;
+    top: 50px;
+}
+
+.j15_org {
+    animation-name: move15_org;
+    top: 50px;
+}
+
+.j16_org {
+    animation-name: move16_org;
+    top: 50px;
+}
+
+.j17_org {
+    animation-name: move17_org;
+    top: 50px;
+}
+
+.j18_org {
+    animation-name: move18_org;
+    top: 50px;
+}
+
+.j19_org {
+    animation-name: move19_org;
+    top: 50px;
+}
+
+.j1a_org {
+    animation-name: move1a_org;
+    top: 50px;
+}
+
+@keyframes move11_org {
+    0% {
+        left: 50px;
+        top: 110px;
+        width: 50px;
+        height: 0px;
+    }
+
+    100% {
+        left: 100px;
+        top: 110px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move12_org {
+    0% {
+        left: 150px;
+        top: 110px;
+        width: 50px;
+        height: 0px;
+    }
+
+    100% {
+        left: 200px;
+        top: 110px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move13_org {
+    0% {
+        left: 300px;
+        top: 60px;
+        width: 50px;
+        height: 0px;
+    }
+
+    100% {
+        left: 300px;
+        top: 110px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move14_org {
+    0% {
+        left: 450px;
+        top: 110px;
+        width: 50px;
+        height: 0px;
+    }
+
+    100% {
+        left: 400px;
+        top: 110px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move15_org {
+    0% {
+        left: 550px;
+        top: 110px;
+        width: 50px;
+        height: 0px;
+    }
+
+    100% {
+        left: 500px;
+        top: 110px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move16_org {
+    0% {
+        left: 550px;
+        top: 110px;
+        width: 50px;
+        height: 0px;
+    }
+
+    100% {
+        left: 600px;
+        top: 110px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move17_org {
+    0% {
+        left: 650px;
+        top: 110px;
+        width: 50px;
+        height: 0px;
+    }
+
+    100% {
+        left: 700px;
+        top: 110px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move18_org {
+    0% {
+        left: 800px;
+        top: 60px;
+        width: 50px;
+        height: 0px;
+    }
+
+    100% {
+        left: 800px;
+        top: 110px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move19_org {
+    0% {
+        left: 950px;
+        top: 110px;
+        width: 50px;
+        height: 0px;
+    }
+
+    100% {
+        left: 900px;
+        top: 110px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move1a_org {
+    0% {
+        left: 1050px;
+        top: 110px;
+        width: 50px;
+        height: 0px;
+    }
+
+    100% {
+        left: 1000px;
+        top: 110px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+.j21_org {
+    animation-name: move21_org;
+    top: 150px;
+}
+
+.j22_org {
+    animation-name: move22_org;
+    top: 150px;
+}
+
+.j23_org {
+    animation-name: move23_org;
+    top: 150px;
+}
+
+.j24_org {
+    animation-name: move24_org;
+    top: 150px;
+}
+
+.j26_org {
+    animation-name: move26_org;
+    top: 150px;
+}
+
+.j27_org {
+    animation-name: move27_org;
+    top: 150px;
+}
+
+.j28_org {
+    animation-name: move28_org;
+    top: 150px;
+}
+
+.j29_org {
+    animation-name: move29_org;
+    top: 150px;
+}
+
+@keyframes move21_org {
+    0% {
+        left: 100px;
+        top: 170px;
+        width: 50px;
+        height: 0px;
+    }
+
+    100% {
+        left: 150px;
+        top: 170px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move22_org {
+    0% {
+        left: 200px;
+        top: 170px;
+        width: 50px;
+        height: 0px;
+    }
+
+    100% {
+        left: 250px;
+        top: 170px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move23_org {
+    0% {
+        left: 400px;
+        top: 170px;
+        width: 50px;
+        height: 0px;
+    }
+
+    100% {
+        left: 350px;
+        top: 170px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move24_org {
+    0% {
+        left: 500px;
+        top: 170px;
+        width: 50px;
+        height: 0px;
+    }
+
+    100% {
+        left: 450px;
+        top: 170px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move26_org {
+    0% {
+        left: 600px;
+        top: 170px;
+        width: 50px;
+        height: 0px;
+    }
+
+    100% {
+        left: 650px;
+        top: 170px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move27_org {
+    0% {
+        left: 700px;
+        top: 170px;
+        width: 50px;
+        height: 0px;
+    }
+
+    100% {
+        left: 750px;
+        top: 170px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move28_org {
+    0% {
+        left: 900px;
+        top: 170px;
+        width: 50px;
+        height: 0px;
+    }
+
+    100% {
+        left: 850px;
+        top: 170px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move29_org {
+    0% {
+        left: 1000px;
+        top: 170px;
+        width: 50px;
+        height: 0px;
+    }
+
+    100% {
+        left: 950px;
+        top: 170px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+.j31_org {
+    animation-name: move31_org;
+    top: 250px;
+}
+
+.j32_org {
+    animation-name: move32_org;
+    top: 250px;
+}
+
+.j33_org {
+    animation-name: move33_org;
+    top: 250px;
+}
+
+.j34_org {
+    animation-name: move34_org;
+    top: 250px;
+}
+
+.j36_org {
+    animation-name: move36_org;
+    top: 250px;
+}
+
+.j37_org {
+    animation-name: move37_org;
+    top: 250px;
+}
+
+.j38_org {
+    animation-name: move38_org;
+    top: 250px;
+}
+
+.j39_org {
+    animation-name: move39_org;
+    top: 250px;
+}
+
+@keyframes move31_org {
+    0% {
+        left: 100px;
+        top: 230px;
+        width: 50px;
+        height: 0px;
+    }
+
+    100% {
+        left: 150px;
+        top: 230px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move32_org {
+    0% {
+        left: 200px;
+        top: 230px;
+        width: 50px;
+        height: 0px;
+    }
+
+    100% {
+        left: 250px;
+        top: 230px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move33_org {
+    0% {
+        left: 400px;
+        top: 230px;
+        width: 50px;
+        height: 0px;
+    }
+
+    100% {
+        left: 350px;
+        top: 230px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move34_org {
+    0% {
+        left: 500px;
+        top: 230px;
+        width: 50px;
+        height: 0px;
+    }
+
+    100% {
+        left: 450px;
+        top: 230px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move36_org {
+    0% {
+        left: 600px;
+        top: 230px;
+        width: 50px;
+        height: 0px;
+    }
+
+    100% {
+        left: 650px;
+        top: 230px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move37_org {
+    0% {
+        left: 700px;
+        top: 230px;
+        width: 50px;
+        height: 0px;
+    }
+
+    100% {
+        left: 750px;
+        top: 230px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move38_org {
+    0% {
+        left: 900px;
+        top: 230px;
+        width: 50px;
+        height: 0px;
+    }
+
+    100% {
+        left: 850px;
+        top: 230px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move39_org {
+    0% {
+        left: 1000px;
+        top: 230px;
+        width: 50px;
+        height: 0px;
+    }
+
+    100% {
+        left: 950px;
+        top: 230px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+.j41_org {
+    animation-name: move41_org;
+    top: 350px;
+}
+
+.j42_org {
+    animation-name: move42_org;
+    top: 350px;
+}
+
+.j43_org {
+    animation-name: move43_org;
+    top: 350px;
+}
+
+.j44_org {
+    animation-name: move44_org;
+    top: 350px;
+}
+
+.j45_org {
+    animation-name: move45_org;
+    top: 350px;
+}
+
+.j46_org {
+    animation-name: move46_org;
+    top: 350px;
+}
+
+.j47_org {
+    animation-name: move47_org;
+    top: 350px;
+}
+
+.j48_org {
+    animation-name: move48_org;
+    top: 350px;
+}
+
+.j49_org {
+    animation-name: move49_org;
+    top: 350px;
+}
+
+.j4a_org {
+    animation-name: move4a_org;
+    top: 350px;
+}
+
+@keyframes move41_org {
+    0% {
+        left: 50px;
+        top: 290px;
+        width: 50px;
+        height: 0px;
+    }
+
+    100% {
+        left: 100px;
+        top: 290px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move42_org {
+    0% {
+        left: 150px;
+        top: 290px;
+        width: 50px;
+        height: 0px;
+    }
+
+    100% {
+        left: 200px;
+        top: 290px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move43_org {
+    0% {
+        left: 300px;
+        top: 340px;
+        width: 50px;
+        height: 0px;
+    }
+
+    100% {
+        left: 300px;
+        top: 290px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move44_org {
+    0% {
+        left: 450px;
+        top: 290px;
+        width: 50px;
+        height: 0px;
+    }
+
+    100% {
+        left: 400px;
+        top: 290px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move45_org {
+    0% {
+        left: 550px;
+        top: 290px;
+        width: 50px;
+        height: 0px;
+    }
+
+    100% {
+        left: 500px;
+        top: 290px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move46_org {
+    0% {
+        left: 550px;
+        top: 290px;
+        width: 50px;
+        height: 0px;
+    }
+
+    100% {
+        left: 600px;
+        top: 290px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move47_org {
+    0% {
+        left: 650px;
+        top: 290px;
+        width: 50px;
+        height: 0px;
+    }
+
+    100% {
+        left: 700px;
+        top: 290px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move48_org {
+    0% {
+        left: 800px;
+        top: 340px;
+        width: 50px;
+        height: 0px;
+    }
+
+    100% {
+        left: 800px;
+        top: 290px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move49_org {
+    0% {
+        left: 950px;
+        top: 290px;
+        width: 50px;
+        height: 0px;
+    }
+
+    100% {
+        left: 900px;
+        top: 290px;
+        width: 50px;
+        height: 50px;
+    }
+}
+
+@keyframes move4a_org {
+    0% {
+        left: 1050px;
+        top: 290px;
+        width: 50px;
+        height: 0px;
+    }
+
+    100% {
+        left: 1000px;
+        top: 290px;
+        width: 50px;
+        height: 50px;
+    }
+}

--- a/js/pstyle.js
+++ b/js/pstyle.js
@@ -13,61 +13,36 @@
 const g_PanpaneVersion = `Ver 1.4.0`;
 
 // 位置の設定、ゲーム名の変更
-const jstyleX = [100, 200, 300, 400, 500, 150, 250, 350, 450, 150, 250, 350, 450, 100, 200, 300, 400, 500];
-const jstyleY = [110, 110, 110, 110, 110, 170, 170, 170, 170, 230, 230, 230, 230, 290, 290, 290, 290, 290];
-g_lblNameObj.dancing = `PUNCHING`;
-g_lblNameObj.star = `◇`;
-g_lblNameObj.onigiri = `PANELS`;
-g_lblNameObj[`u_key`] = `panel`;
-g_lblNameObj[`u_k-`] = `p-`;
-g_lblNameObj.Reverse = `Dynamic`;
-g_lblNameObj[`u_Reverse`] = `Dynamic`;
-g_lang_msgObj.Ja.reverse = `パネルの移動パターンを変更します。`;
-g_lang_msgObj.En.reverse = `Change the panel movement pattern.`;
-g_rootObj.arrowEffectUse = `false,ON`;
-
-/**
- * タイトル画面の割込み処理
- */
-function pstyleTitleInit() {
-
-	// キリズマ拡張クレジット
-	multiAppend(divRoot,
-		createCss2Button(`lnkCreditP`, `Punching◇Panels ${g_PanpaneVersion}`, _ => openLink(`https://github.com/cwtickle/punching-panels`), {
-			x: g_sWidth - 175, y: 0, w: 175, h: 20, siz: 12, align: C_ALIGN_RIGHT,
-		}, g_cssObj.button_Setting),
-	);
-}
-g_customJsObj.title.push(pstyleTitleInit);
-
-// カスタムキー定義
-const pstyle18LibData = `
-|keyName18p=18,panel|
-|keyCtrl18p=
-D7,D8,D9,D0,Minus,U,I,O,P,J,K,L,Semicolon,N,M,Comma,Period,Slash
-D2,D3,D4,D5,D6,W,E,R,T,S,D,F,G,Z,X,C,V,B
-|
-|chara18p=aa,ab,ac,ad,ae,ba,bb,bc,bd,ca,cb,cc,cd,da,db,dc,dd,de$18p_0|
-|color18p=0,1,2,3,4,0,1,3,4,0,1,3,4,0,1,2,3,4$18p_0|
-|shuffle18p=0,0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3,3/0,1,2,3,4,0,1,3,4,0,1,3,4,0,1,2,3,4/0,1,2,3,4,0,1,3,4,4,3,1,0,4,3,2,1,0$18p_0|
-|stepRtn18p=c,c,c,c,c,c,c,c,c,c,c,c,c,c,c,c,c,c$18p_0|
-|minWidth18p=650|
-`;
-g_presetObj.keysDataLib.push(pstyle18LibData);
-g_rootObj.imgType = `panels,svg,true,0`;
-g_rootObj.arrowJdgY = -160;
-
-// デフォルト配列のコピー (g_keyObj.aaa_X から g_keyObj.aaa_Xd を作成)
-const keyCtrlNameP = Object.keys(g_keyObj).filter(val => val.startsWith(`keyCtrl18p`));
-keyCtrlNameP.forEach(property => g_keyObj[`${property}d`] = copyArray2d(g_keyObj[property]));
-
-[`color18p`, `shuffle18p`].forEach(type => {
-	const tmpName = Object.keys(g_keyObj).filter(val => val.startsWith(type) && val.endsWith(`_0`));
-	tmpName.forEach(property => g_keyObj[`${property.slice(0, -2)}`] = g_keyObj[property].concat());
-});
-
-// 矢印モーション初期定義
-g_rootObj.arrowMotion_data = `
+const pstyleX = {
+	'18p': [
+		100, 200, 300, 400, 500,
+		150, 250, 350, 450,
+		150, 250, 350, 450,
+		100, 200, 300, 400, 500,
+	],
+	'36p': [
+		100, 200, 300, 400, 500, 600, 700, 800, 900, 1000,
+		150, 250, 350, 450, 650, 750, 850, 950,
+		150, 250, 350, 450, 650, 750, 850, 950,
+		100, 200, 300, 400, 500, 600, 700, 800, 900, 1000,
+	],
+};
+const pstyleY = {
+	'18p': [
+		110, 110, 110, 110, 110,
+		170, 170, 170, 170,
+		230, 230, 230, 230,
+		290, 290, 290, 290, 290,
+	],
+	'36p': [
+		110, 110, 110, 110, 110, 110, 110, 110, 110, 110,
+		170, 170, 170, 170, 170, 170, 170, 170,
+		230, 230, 230, 230, 230, 230, 230, 230,
+		290, 290, 290, 290, 290, 290, 290, 290, 290, 290,
+	],
+};
+const pMotion = {
+	'18p': `
 0,0,j11_org,j11
 0,1,j12_org,j12
 0,2,j13_org,j13
@@ -86,20 +61,124 @@ g_rootObj.arrowMotion_data = `
 0,15,j43_org,j43
 0,16,j44_org,j44
 0,17,j45_org,j45
-`;
+	`,
+	'36p': `
+0,0,j11_org,j11
+0,1,j12_org,j12
+0,2,j13_org,j13
+0,3,j14_org,j14
+0,4,j15_org,j15
+0,5,j16_org,j16
+0,6,j17_org,j17
+0,7,j18_org,j18
+0,8,j19_org,j19
+0,9,j1a_org,j1a
+0,10,j21_org,j21
+0,11,j22_org,j22
+0,12,j23_org,j23
+0,13,j24_org,j24
+0,14,j26_org,j26
+0,15,j27_org,j27
+0,16,j28_org,j28
+0,17,j29_org,j29
+0,18,j31_org,j31
+0,19,j32_org,j32
+0,1020,j33_org,j33
+0,1021,j34_org,j34
+0,1022,j36_org,j36
+0,1023,j37_org,j37
+0,1024,j38_org,j38
+0,1025,j39_org,j39
+0,1026,j41_org,j41
+0,1027,j42_org,j42
+0,1028,j43_org,j43
+0,1029,j44_org,j44
+0,1030,j45_org,j45
+0,1031,j46_org,j46
+0,1032,j47_org,j47
+0,1033,j48_org,j48
+0,1034,j49_org,j49
+0,1035,j4a_org,j4a
+	`,
+};
+
+g_lblNameObj.dancing = `PUNCHING`;
+g_lblNameObj.star = `◇`;
+g_lblNameObj.onigiri = `PANELS`;
+g_lblNameObj[`u_key`] = `panel`;
+g_lblNameObj[`u_k-`] = `p-`;
+g_lblNameObj.Reverse = `Dynamic`;
+g_lblNameObj[`u_Reverse`] = `Dynamic`;
+g_lang_msgObj.Ja.reverse = `パネルの移動パターンを変更します。`;
+g_lang_msgObj.En.reverse = `Change the panel movement pattern.`;
+g_rootObj.arrowEffectUse = `false,ON`;
+
+/**
+ * タイトル画面の割込み処理
+ */
+g_customJsObj.title.push(() => {
+	// 拡張クレジット
+	multiAppend(divRoot,
+		createCss2Button(`lnkCreditP`, `Punching◇Panels ${g_PanpaneVersion}`, _ => openLink(`https://github.com/cwtickle/punching-panels`), {
+			x: g_btnWidth() + g_btnX() - 175, y: 0, w: 175, h: 20, siz: 12, align: C_ALIGN_RIGHT,
+		}, g_cssObj.button_Setting),
+	);
+});
+
+/**
+ * カスタムキー定義
+ */
+g_presetObj.keysDataLib.push(`
+|keyName18p=18,panel|
+|keyCtrl18p=
+D7,D8,D9,D0,Minus,U,I,O,P,J,K,L,Semicolon,N,M,Comma,Period,Slash
+D2,D3,D4,D5,D6,W,E,R,T,S,D,F,G,Z,X,C,V,B
+|
+|chara18p=aa,ab,ac,ad,ae,ba,bb,bc,bd,ca,cb,cc,cd,da,db,dc,dd,de$18p_0|
+|color18p=0,1,2,3,4,0,1,3,4,0,1,3,4,0,1,2,3,4$18p_0|
+|shuffle18p=0,0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3,3/0,1,2,3,4,0,1,3,4,0,1,3,4,0,1,2,3,4/0,1,2,3,4,0,1,3,4,4,3,1,0,4,3,2,1,0$18p_0|
+|stepRtn18p=c,c,c,c,c,c,c,c,c,c,c,c,c,c,c,c,c,c$18p_0|
+|minWidth18p=650|
+
+|keyName36p=36,panel|
+|keyCtrl36p=
+D2,D3,D4,D5,D6,D7,D8,D9,D0,Minus,W,E,R,T,U,I,O,P,S,D,F,G,J,K,L,Semicolon,Z,X,C,V,B,N,M,Comma,Period,Slash
+D1,D2,D3,D4,D5,D7,D8,D9,D0,Minus,Q,W,E,R,U,I,O,P,A,S,D,F,J,K,L,Semicolon,ShiftLeft,Z,X,C,V,N,M,Comma,Period,Slash
+|
+|chara36p=aa,ab,ac,ad,ae,af,ag,ah,ai,aj,ba,bb,bc,bd,bf,bg,bh,bi,ca,cb,cc,cd,cf,cg,ch,ci,da,db,dc,dd,de,df,dg,dh,di,dj$36p_0|
+|color36p=0,1,2,3,4,0,1,2,3,4,0,1,3,4,0,1,3,4,0,1,3,4,0,1,3,4,0,1,2,3,4,0,1,2,3,4$36p_0|
+|shuffle36p=0,0,0,0,0,1,1,1,1,1,0,0,0,0,1,1,1,1,0,0,0,0,1,1,1,1,0,0,0,0,0,1,1,1,1,1$36p_0|
+|stepRtn36p=c,c,c,c,c,c,c,c,c,c,c,c,c,c,c,c,c,c,c,c,c,c,c,c,c,c,c,c,c,c,c,c,c,c,c,c$36p_0|
+|minWidth36p=1200|
+`);
+g_rootObj.imgType = `panels,svg,true,0`;
+g_rootObj.arrowJdgY = -160;
+
+// デフォルト配列のコピー (g_keyObj.aaa_X から g_keyObj.aaa_Xd を作成)
+const keyCtrlNameP = Object.keys(g_keyObj).filter(val => val.startsWith(`keyCtrl18p`) || val.startsWith(`keyCtrl36p`));
+keyCtrlNameP.forEach(property => g_keyObj[`${property}d`] = copyArray2d(g_keyObj[property]));
+
+[`color18p`, `shuffle18p`, `color36p`, `shuffle36p`].forEach(type => {
+	const tmpName = Object.keys(g_keyObj).filter(val => val.startsWith(type) && val.endsWith(`_0`));
+	tmpName.forEach(property => g_keyObj[`${property.slice(0, -2)}`] = g_keyObj[property].concat());
+});
+
+// 矢印モーション初期定義
+g_customJsObj.preloading.push(() => {
+	g_rootObj.arrowMotion_data = pMotion[g_keyObj.currentKey];
+});
 
 // ステップゾーンの位置変更 (ノーツはCSS側で制御)
-function pstyleMainInit() {
-	if ([`18p`].includes(g_keyObj.currentKey)) {
-		for (let i = 0; i < 18; i++) {
+g_customJsObj.main.push(() => {
+	if ([`18p`, `36p`].includes(g_keyObj.currentKey)) {
+		for (let i = 0; i < g_keyObj[`keyCtrl${g_keyObj.currentKey}_0`].length; i++) {
 			if (document.getElementById(`stepRoot${i}`)) {
-				document.getElementById(`stepRoot${i}`).style.left = `${jstyleX[i]}px`;
-				document.getElementById(`stepRoot${i}`).style.top = `${jstyleY[i]}px`;
+				document.getElementById(`stepRoot${i}`).style.left = `${pstyleX[g_keyObj.currentKey][i]}px`;
+				document.getElementById(`stepRoot${i}`).style.top = `${pstyleY[g_keyObj.currentKey][i]}px`;
 			}
 		}
 	}
-}
-g_customJsObj.main.push(pstyleMainInit);
+});
 
 // ライセンス原文、以下は削除しないでください
 /*-----------------------------------------------------------*/

--- a/punpane/Komichi_dp.html
+++ b/punpane/Komichi_dp.html
@@ -42,13 +42,13 @@ a:hover  { color:#FF9900; text-decoration: underline; }
 <input type="hidden" name="dos" id="dos" value='
 		
 |musicTitle=こみちをかけぬけて,みそか,https://cw7.sakura.ne.jp/rdart/?artistId=285|
-|difData=18p,Basic,5.5,70,2,5|
+|difData=36p,Basic,5.5,70,2,5|
 |setColor=#9999ff,#ccffff,#ffffff,#ffff99,#ff9966|
 |startFrame=0|blankFrame=200|endFrame=1:09|
 |musicUrl=nosound.mp3|
 
 |hashTag=#punpane|
-|customcss=pstyle.css|
+|customcss=pstyle_36p.css|
 |customjs=pstyle.js|
 
 |aa_data=3169|


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
### 1. 36Panel 対応
- 従来の18 Panelに加えて、36 Panelモードを使えるようにしました。
- jsは統合しましたが、cssは適用するクラスが多く管理が難しいためキー毎に分離しています。
このため、18 Panelと36 Panelを同じ作品内に収めることはできません。
- 36 Panelを使う場合、譜面データに以下を追加する必要があります。
```
|hashTag=#punpane|
|customcss=pstyle_36p.css|  // customCssのみ"pstyle_36p.css"を適用
|customjs=pstyle.js|
```

### 2. コードの整理
- 既存変数と被らないように、変数定義している箇所を減らしました。

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. すでに36 Panelの作品が複数あるのと、今後のソース更新に追従できないため。
2. 上述の通りです。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->
<img src="https://github.com/user-attachments/assets/a36d8fb7-c3a7-47cc-8cad-d5463a9fd00d" width="80%">

## :pencil: その他コメント / Other Comments
- サンプルを追加しましたが、既存サンプルが作れなかったので既存譜面から作成しました。
