### PR TITLE
feat: [0017] ハッシュタグ指定が無くても自動でパンパネ用のハッシュタグを付加する設定を追加

### DIFF
--- a/js/pstyle.js
+++ b/js/pstyle.js
@@ -155,6 +155,8 @@ g_customJsObj.preTitle.push(() => {
 			C_IMG_C: `data:image/svg+xml,${encodeURIComponent('<svg id="c" data-name="c" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 500"><path d="M495,5V495H5V5H495m5-5H0V500H500V0Z"/></svg>')}`,
 		};
 
+		const orgHashTag = g_headerObj.hashTag;
+
 		// 現在選択中のkeyLabelに応じて都度切り替える
 		g_customJsObj.difficulty.push(() => {
 			if (!isPanelKey(g_keyObj.prevKey) && isPanelKey(g_keyObj.currentKey)) {
@@ -180,6 +182,14 @@ g_customJsObj.preTitle.push(() => {
 				g_headerObj.imgType = panelsImgTypeArr;
 				g_keycons.imgTypes = panelsImgTypeNames;
 
+				if (hasVal(orgHashTag)) {
+					if (!orgHashTag.includes(`#punpane`)) {
+						g_headerObj.hashTag = orgHashTag + ` #punpane`;
+					}
+				} else {
+					g_headerObj.hashTag = `#punpane`;
+				}
+
 				if (g_imgType !== `panels`) {
 					g_imgType = `panels`;
 					g_stateObj.rotateEnabled = panelsImgTypeArr[0].rotateEnabled;
@@ -204,6 +214,12 @@ g_customJsObj.preTitle.push(() => {
 
 				g_headerObj.imgType = origImgTypeArr;
 				g_keycons.imgTypes = origImgTypeNames;
+
+				if (hasVal(orgHashTag)) {
+					g_headerObj.hashTag = orgHashTag;
+				} else {
+					delete g_headerObj.hashTag;
+				}
 
 				if (g_imgType !== origImgTypeNames[0]) {
 					g_imgType = origImgTypeNames[0];

--- a/punpane/Komichi.html
+++ b/punpane/Komichi.html
@@ -47,9 +47,8 @@ a:hover  { color:#FF9900; text-decoration: underline; }
 |startFrame=0|blankFrame=200|endFrame=1:09|
 |musicUrl=nosound.mp3|
 
-|hashTag=#punpane|
-|customcss=pstyle.css,kstyle.css|
-|customjs=pstyle.js,kstyle.js|
+|customcss=pstyle.css|
+|customjs=pstyle.js|
 
 |aa_data=3169|
 |ab_data=2977,3133,3361|
@@ -127,7 +126,7 @@ a:hover  { color:#FF9900; text-decoration: underline; }
 <hr>
 |
 
-|tuning=ティックル|hashTag=#punpane|
+|tuning=ティックル|
 '>
 <div id="canvas-frame">
 	<p>ゲームを準備しています...</p>


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
### 1. ハッシュタグ指定が無くても自動でパンパネ用のハッシュタグを付加する設定を追加
- 明示的なハッシュタグ指定が不要になりました。
- パンパネと判定された場合、自動でハッシュタグ「#punpane」が付加されます。

<!--
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->
1. PR #27 の変更により、パンパネ以外の譜面が混在するようになったため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments
