### PR TITLE
fix: [0018] 無効化したオプションが初期化されない問題を修正

### DIFF
--- a/js/pstyle.js
+++ b/js/pstyle.js
@@ -123,11 +123,11 @@ g_customJsObj.preTitle.push(() => {
 
 		// 標準側の元の値を退避
 		const origArrowEffectUseOrg = g_headerObj.arrowEffectUseOrg;
-		const origDArrowEffect = g_stateObj.d_arroweffect;
 		const origStepAreaUse = g_headerObj.stepAreaUse;
 		const origEffectUse = g_headerObj.effectUse;
 		const origCamoufrageUse = g_headerObj.camoufrageUse;
 		const origSwappingUse = g_headerObj.swappingUse;
+		let savedStepArea, savedEffect, savedCamoufrage, savedSwapping, savedDArrowEffect;
 		const origArrowJdgY = g_diffObj.arrowJdgY;
 
 		// ラベル文言も標準側を退避
@@ -160,6 +160,13 @@ g_customJsObj.preTitle.push(() => {
 		// 現在選択中のkeyLabelに応じて都度切り替える
 		g_customJsObj.difficulty.push(() => {
 			if (!isPanelKey(g_keyObj.prevKey) && isPanelKey(g_keyObj.currentKey)) {
+
+				// panelsに入る直前の実際の値を退避
+				savedStepArea = g_stateObj.stepArea;
+				savedEffect = g_stateObj.effect;
+				savedCamoufrage = g_stateObj.camoufrage;
+				savedSwapping = g_stateObj.swapping;
+				savedDArrowEffect = g_stateObj.d_arroweffect;
 
 				// パンパネで起動しない設定を無効化
 				g_headerObj.arrowEffectUse = false;
@@ -251,11 +258,15 @@ g_customJsObj.preTitle.push(() => {
 				lblReverse.title = origMsgReverse;
 
 				g_headerObj.arrowEffectUse = origArrowEffectUseOrg;
-				g_stateObj.d_arroweffect = origDArrowEffect;
 				g_headerObj.stepAreaUse = origStepAreaUse;
 				g_headerObj.effectUse = origEffectUse;
 				g_headerObj.camoufrageUse = origCamoufrageUse;
 				g_headerObj.swappingUse = origSwappingUse;
+				g_stateObj.stepArea = savedStepArea;
+				g_stateObj.effect = savedEffect;
+				g_stateObj.camoufrage = savedCamoufrage;
+				g_stateObj.swapping = savedSwapping;
+				g_stateObj.d_arroweffect = savedDArrowEffect;
 				deleteDiv(divRoot, `lnkCreditP`);
 			}
 


### PR DESCRIPTION
## :hammer: 変更内容 / Details of Changes
### 1. 無効化したオプションが初期化されない問題を修正

- 無効化したオプションが初期化されないため、適用されてはいけない設定が適用されうる状態になっていました。
<!--
```
// コードや譜面ヘッダーの仕様変更の場合は、このように例示して記述してください。
```
-->

## :bookmark: 関連Issue, 変更理由 / Related Issues, Reason for Changes
<!-- 今回の変更に関連したIssue番号 もしくは GitterコメントやTwitterのリンクを入れてください -->
<!-- いずれにも該当しない場合は、変更理由を書いてください -->

1. 上記記述の問題があるため。

## :camera: スクリーンショット / Screenshot
<!-- 変更点に関して、画面デザインを変更する場合はスクリーンショットを貼ってください -->

## :pencil: その他コメント / Other Comments

- キリズマ側の設定無効化は無くす予定のため、パンパネの前後で設定をブロックする設定に変更しています。